### PR TITLE
fix issue with python tests not running during builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,37 @@ wsk action update myAction myAction.py --docker $user_prefix/action-python-v3
 ```
 The `$user_prefix` is usually your dockerhub user id.
 
+
 ### Testing
+Install dependencies from the root directory on $OPENWHISK_HOME repository
+```
+./gradlew :common:scala:install :core:controller:install :core:invoker:install :tests:install
+```
+
+Using gradle to run all tests
+```
+./gradlew :tests:test
+```
+Using gradle to run some tests
+```
+./gradlew :tests:test --tests *ActionContainerTests*
+```
+Using IntelliJ:
+- Import project as gradle project.
+- Make sure working directory is root of the project/repo
 
 
-To run all tests: `./gradlew tests:test` this include tests depending on credentials
-
-To run all tests except those which do not rely on credentials `./gradlew tests:testWithoutCredentials`
-
-To run a single test-class: `./gradlew tests:test --tests <SomeGradleTestFilter>`
+#### Using container image to test
+To use as docker action push to your own dockerhub account
+```
+docker tag whisk/action-python-v3 $user_prefix/action-python-v3
+docker push $user_prefix/action-python-v3
+```
+Then create the action using your the image from dockerhub
+```
+wsk action update myAction myAction.py --docker $user_prefix/action-python-v3
+```
+The `$user_prefix` is usually your dockerhub user id.
 
 
 # License

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,11 +1,3 @@
-def owPath = System.getenv("OPENWHISK_HOME") ?: '../open'
-def owDirectory = new File(owPath)
-
-include 'common:scala'; project(':common:scala').projectDir = new File(owDirectory, 'common/scala')
-include 'core:controller'; project(':core:controller').projectDir = new File(owDirectory, 'core/controller')
-include 'core:invoker'; project(':core:invoker').projectDir = new File(owDirectory, 'core/invoker')
-include 'whisktests'; project(':whisktests').projectDir = new File(owDirectory, 'tests')
-
 include 'tests'
 
 include 'python3'


### PR DESCRIPTION
See issue: #31 
PR addresses issues discovered where the python tests were failing to run during our Jenkins builds. 
The builds showed, 
```
[runtime-python-ibm] Running shell script
+ ./gradlew :tests:testBlueCI -Dtestthreads=3 -Ddeploy.target=jenkins -PdockerImageTag=latest

FAILURE: Build failed with an exception.

* Where:
Build file '/home/cusina/workspace/mainWhisk/open/tests/build.gradle' line: 1

* What went wrong:
Could not compile build file '/home/cusina/workspace/mainWhisk/open/tests/build.gradle'.
> startup failed:
  build file '/home/cusina/workspace/mainWhisk/open/tests/build.gradle': 1: unable to resolve class org.scoverage.ScoverageReport
   @ line 1, column 1.
     import org.scoverage.ScoverageReport
     ^
```

The python runtime needed to be updated to reference the tests paradigm set up in the other IBM Runtime repos. 