### PR TITLE
update outdated packages, May 29

### DIFF
--- a/python3/CHANGELOG.md
+++ b/python3/CHANGELOG.md
@@ -1,13 +1,13 @@
 # IBM Functions Python 3 Runtime Container
 
-## 1.6.0
-- add Pillow `5.1.0`
-- update elasticsearch from `5.5.2` to `6.2.0`
-- update gevent from `1.2.2` to `1.3.0`
+## 1.7.0
+- update kafka_python from `1.4.2` to `1.4.3`
+- update pandas from `0.22.0` to `0.23.0`
 - update python-dateutil from `2.7.2` to `2.7.3`
 - update scipy from `1.0.1` to `1.1.0`
 - update simplejson from `3.14.0` to `3.15.0`
-- update tornado from `4.5.2` to `5.0.2`
+- update virtualenv from `15.2.0` to `16.0.0`
+- update watson-developer-cloud from `1.3.3` to `1.3.4`
 
 Python version:
 - [3.6.5](https://github.com/docker-library/python/blob/b99b66406ebe728fb4da64548066ad0be6582e08/3.6/jessie/Dockerfile)
@@ -31,7 +31,83 @@ Python packages:
 - docutils (0.14)
 - elasticsearch (6.2.0)
 - Flask (1.0.2)
-- gevent (1.3.0)
+- gevent (1.2.2)
+- greenlet (0.4.13)
+- httplib2 (0.11.3)
+- hyperlink (18.0.0)
+- ibm-cos-sdk (2.1.1)
+- ibm-db (2.0.8a0)
+- ibmcloudsql (0.2.13)
+- idna (2.6)
+- incremental (17.5.0)
+- itsdangerous (0.24)
+- Jinja2 (2.10)
+- jmespath (0.9.3)
+- kafka-python (1.4.3)
+- lxml (4.2.1)
+- MarkupSafe (1.0)
+- numpy (1.14.3)
+- pandas (0.23.0)
+- parsel (1.4.0)
+- pika (0.11.2)
+- Pillow (5.1.0)
+- psycopg2 (2.7.4)
+- pyasn1 (0.4.2)
+- pyasn1-modules (0.2.1)
+- pycparser (2.18)
+- PyDispatcher (2.0.5)
+- pymongo (3.6.1)
+- pyOpenSSL (17.5.0)
+- pysolr (3.7.0)
+- python-dateutil (2.7.3)
+- pytz (2018.4)
+- queuelib (1.5.0)
+- redis (2.10.6)
+- requests (2.18.4)
+- scikit-learn (0.19.1)
+- scipy (1.1.0)
+- Scrapy (1.5.0)
+- service-identity (17.0.0)
+- simplejson (3.15.0)
+- six (1.11.0)
+- tornado (5.0.2)
+- Twisted (18.4.0)
+- txaio (2.10.0)
+- urllib3 (1.22)
+- virtualenv (16.0.0)
+- w3lib (1.19.0)
+- watson-developer-cloud (1.3.4)
+- Werkzeug (0.14.1)
+- wheel (0.30.0)
+- zope.interface (4.4.3)
+
+## 1.6.0
+- add Pillow `5.1.0`
+- update tornado from `4.5.2` to `5.0.2`
+
+Python version:
+- [3.6.5](https://github.com/docker-library/python/blob/b99b66406ebe728fb4da64548066ad0be6582e08/3.6/jessie/Dockerfile)
+
+Python packages:
+- asn1crypto (0.24.0)
+- attrs (17.4.0)
+- autobahn (18.4.1)
+- Automat (0.6.0)
+- beautifulsoup4 (4.6.0)
+- botocore (1.10.4)
+- cassandra-driver (3.14.0)
+- certifi (2018.1.18)
+- cffi (1.11.5)
+- chardet (3.0.4)
+- click (6.7)
+- cloudant (2.8.1)
+- constantly (15.1.0)
+- cryptography (2.2.2)
+- cssselect (1.0.3)
+- docutils (0.14)
+- elasticsearch (5.5.2)
+- Flask (1.0.2)
+- gevent (1.2.2)
 - greenlet (0.4.13)
 - httplib2 (0.11.3)
 - hyperlink (18.0.0)
@@ -59,18 +135,18 @@ Python packages:
 - pymongo (3.6.1)
 - pyOpenSSL (17.5.0)
 - pysolr (3.7.0)
-- python-dateutil (2.7.3)
+- python-dateutil (2.7.2)
 - pytz (2018.4)
 - queuelib (1.5.0)
 - redis (2.10.6)
 - requests (2.18.4)
 - scikit-learn (0.19.1)
-- scipy (1.1.0)
+- scipy (1.0.1)
 - Scrapy (1.5.0)
 - service-identity (17.0.0)
-- simplejson (3.15.0)
+- simplejson (3.14.0)
 - six (1.11.0)
-- tornado (5.0.2)
+- tornado (4.5.2)
 - Twisted (18.4.0)
 - txaio (2.10.0)
 - urllib3 (1.22)

--- a/python3/requirements.txt
+++ b/python3/requirements.txt
@@ -7,20 +7,20 @@ flask == 1.0.2
 # default available packages for python3action
 beautifulsoup4 == 4.6.0
 httplib2 == 0.11.3
-kafka_python == 1.4.2
+kafka_python == 1.4.3
 lxml == 4.2.1
-python-dateutil == 2.7.2
+python-dateutil == 2.7.3
 requests == 2.18.4
 scrapy == 1.5.0
-simplejson == 3.14.0
-virtualenv == 15.2.0
+simplejson == 3.15.0
+virtualenv == 16.0.0
 twisted == 18.4.0
 
 # packages for numerics
 numpy == 1.14.3
 scikit-learn == 0.19.1
-scipy == 1.0.1
-pandas == 0.22.0
+scipy == 1.1.0
+pandas == 0.23.0
 
 # packages for image processing
 Pillow == 5.1.0
@@ -28,7 +28,7 @@ Pillow == 5.1.0
 # IBM specific python modules
 ibm_db == 2.0.8a
 cloudant == 2.8.1
-watson-developer-cloud == 1.3.3
+watson-developer-cloud == 1.3.4
 ibm-cos-sdk == 2.1.1
 ibmcloudsql == 0.2.13
 


### PR DESCRIPTION
Packages changed:
update gevent from `1.3.0` to `1.3.2`
update kafka_python from `1.4.2` to `1.4.3`
update pandas from `0.22.0` to `0.23.0`
update python-dateutil from `2.7.2` to `2.7.3`
update scipy from `1.0.1` to `1.1.0`
update simplejson from `3.14.0` to `3.15.0`
update virtualenv from `15.2.0` to `16.0.0`
update watson-developer-cloud from `1.3.3` to `1.3.4`