### PR TITLE
update packages, runtimes bug, and lock travis to repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ deploy:
     script: "./tools/travis/publish.sh ibmfunctions master"
     on:
       branch: master
+      repo: ibm-functions/runtime-python
   - provider: script
     script: "./tools/travis/publish.sh ibmfunctions $TRAVIS_TAG"
     on:

--- a/ansible/environments/local/group_vars/all
+++ b/ansible/environments/local/group_vars/all
@@ -27,8 +27,6 @@ env_hosts_dir: "{{ playbook_dir }}/environments/local"
 
 skip_pull_runtimes: true
 runtimes_manifest:
-  defaultImagePrefix: "openwhisk"
-  defaultImageTag: "latest"
   runtimes:
     nodejs:
     - kind: "nodejs:6"

--- a/ansible/environments/local/group_vars/all
+++ b/ansible/environments/local/group_vars/all
@@ -25,6 +25,7 @@ apigw_host_v2: "http://{{ groups['apigateway']|first }}:{{apigateway.port.api}}/
 invoker_allow_multiple_instances: true
 env_hosts_dir: "{{ playbook_dir }}/environments/local"
 
+skip_pull_runtimes: true
 runtimes_manifest:
   defaultImagePrefix: "openwhisk"
   defaultImageTag: "latest"

--- a/python3/CHANGELOG.md
+++ b/python3/CHANGELOG.md
@@ -1,5 +1,86 @@
 # IBM Functions Python 3 Runtime Container
 
+## 1.9.0
+- update gevent from `1.2.2` to `1.3.3`
+- update requests from `2.18.4` to `2.19.1`
+- update numpy from `1.14.4` to `1.14.5`
+- update pandas from `0.23.0` to `0.23.1`
+- update cloudant from `2.8.1` to `2.9.0`
+- update watson-developer-cloud from `1.3.5` to `1.4.0`
+- update psycopg2 from `2.7.4` to `2.7.5`
+- update pika from `0.11.2` to `0.12.0`
+
+Python version:
+- [3.6.5](https://github.com/docker-library/python/blob/b99b66406ebe728fb4da64548066ad0be6582e08/3.6/jessie/Dockerfile)
+
+Python packages:
+- asn1crypto (0.24.0)
+- attrs (17.4.0)
+- autobahn (18.4.1)
+- Automat (0.6.0)
+- beautifulsoup4 (4.6.0)
+- botocore (1.10.4)
+- cassandra-driver (3.14.0)
+- certifi (2018.1.18)
+- cffi (1.11.5)
+- chardet (3.0.4)
+- click (6.7)
+- cloudant (2.9.0)
+- constantly (15.1.0)
+- cryptography (2.2.2)
+- cssselect (1.0.3)
+- docutils (0.14)
+- elasticsearch (6.2.0)
+- Flask (1.0.2)
+- gevent (1.3.3)
+- greenlet (0.4.13)
+- httplib2 (0.11.3)
+- hyperlink (18.0.0)
+- ibm-cos-sdk (2.1.1)
+- ibm-db (2.0.8a0)
+- ibmcloudsql (0.2.13)
+- idna (2.6)
+- incremental (17.5.0)
+- itsdangerous (0.24)
+- Jinja2 (2.10)
+- jmespath (0.9.3)
+- kafka-python (1.4.3)
+- lxml (4.2.1)
+- MarkupSafe (1.0)
+- numpy (1.14.5)
+- pandas (0.23.1)
+- parsel (1.4.0)
+- pika (0.12.0)
+- Pillow (5.1.0)
+- psycopg2 (2.7.5)
+- pyasn1 (0.4.2)
+- pyasn1-modules (0.2.1)
+- pycparser (2.18)
+- PyDispatcher (2.0.5)
+- pymongo (3.6.1)
+- pyOpenSSL (17.5.0)
+- pysolr (3.7.0)
+- python-dateutil (2.7.3)
+- pytz (2018.4)
+- queuelib (1.5.0)
+- redis (2.10.6)
+- requests (2.19.1)
+- scikit-learn (0.19.1)
+- scipy (1.1.0)
+- Scrapy (1.5.0)
+- service-identity (17.0.0)
+- simplejson (3.15.0)
+- six (1.11.0)
+- tornado (5.0.2)
+- Twisted (18.4.0)
+- txaio (2.10.0)
+- urllib3 (1.22)
+- virtualenv (16.0.0)
+- w3lib (1.19.0)
+- watson-developer-cloud (1.4.0)
+- Werkzeug (0.14.1)
+- wheel (0.30.0)
+- zope.interface (4.4.3)
 ## 1.8.0
 - update numpy from `1.14.3` to `1.14.4`
 - update watson-developer-cloud from `1.3.4` to `1.3.5`

--- a/python3/CHANGELOG.md
+++ b/python3/CHANGELOG.md
@@ -1,7 +1,6 @@
 # IBM Functions Python 3 Runtime Container
 
 ## 1.9.0
-- update gevent from `1.2.2` to `1.3.3`
 - update requests from `2.18.4` to `2.19.1`
 - update numpy from `1.14.4` to `1.14.5`
 - update pandas from `0.23.0` to `0.23.1`
@@ -32,7 +31,7 @@ Python packages:
 - docutils (0.14)
 - elasticsearch (6.2.0)
 - Flask (1.0.2)
-- gevent (1.3.3)
+- gevent (1.2.2)
 - greenlet (0.4.13)
 - httplib2 (0.11.3)
 - hyperlink (18.0.0)

--- a/python3/requirements.txt
+++ b/python3/requirements.txt
@@ -1,7 +1,7 @@
 # Requirements.txt contains a list of dependencies for the Python Application #
 
 # Setup modules
-gevent == 1.3.3
+gevent == 1.2.2
 flask == 1.0.2
 
 # default available packages for python3action

--- a/python3/requirements.txt
+++ b/python3/requirements.txt
@@ -1,7 +1,7 @@
 # Requirements.txt contains a list of dependencies for the Python Application #
 
 # Setup modules
-gevent == 1.2.2
+gevent == 1.3.3
 flask == 1.0.2
 
 # default available packages for python3action
@@ -10,32 +10,32 @@ httplib2 == 0.11.3
 kafka_python == 1.4.3
 lxml == 4.2.1
 python-dateutil == 2.7.3
-requests == 2.18.4
+requests == 2.19.1
 scrapy == 1.5.0
 simplejson == 3.15.0
 virtualenv == 16.0.0
 twisted == 18.4.0
 
 # packages for numerics
-numpy == 1.14.4
+numpy == 1.14.5
 scikit-learn == 0.19.1
 scipy == 1.1.0
-pandas == 0.23.0
+pandas == 0.23.1
 
 # packages for image processing
 Pillow == 5.1.0
 
 # IBM specific python modules
 ibm_db == 2.0.8a
-cloudant == 2.8.1
-watson-developer-cloud == 1.3.5
+cloudant == 2.9.0
+watson-developer-cloud == 1.4.0
 ibm-cos-sdk == 2.1.1
 ibmcloudsql == 0.2.13
 
 # Compose Libs
-psycopg2 == 2.7.4
+psycopg2 == 2.7.5
 pymongo == 3.6.1
 redis == 2.10.6
-pika == 0.11.2
+pika == 0.12.0
 elasticsearch >=5.0.0,<6.0.0
 cassandra-driver == 3.14.0

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -19,9 +19,9 @@ docker tag openwhisk/controller ${IMAGE_PREFIX}/controller
 docker pull openwhisk/invoker
 docker tag openwhisk/invoker ${IMAGE_PREFIX}/invoker
 docker pull openwhisk/nodejs6action
-docker tag openwhisk/nodejs6action ${IMAGE_PREFIX}/nodejs6action
+docker tag openwhisk/nodejs6action nodejs6action
 docker pull openwhisk/python2action
-docker tag openwhisk/python2action ${IMAGE_PREFIX}/python2action
+docker tag openwhisk/python2action python2action
 
 TERM=dumb ./gradlew \
 :common:scala:install \


### PR DESCRIPTION
This PR tackles three things:
1) It locks down the deploy section in .travis.yml to only execute when the repo is == 'ibm-functions/runtime-python'
2) It brings in a fix for an recent change to Runtimes, where we need to skip pulling runtime images
3) It updates the Python runtime's and packages:
+- update gevent from `1.2.2` to `1.3.3`
+- update requests from `2.18.4` to `2.19.1`
+- update numpy from `1.14.4` to `1.14.5`
+- update pandas from `0.23.0` to `0.23.1`
+- update cloudant from `2.8.1` to `2.9.0`
+- update watson-developer-cloud from `1.3.5` to `1.4.0`
+- update psycopg2 from `2.7.4` to `2.7.5`
+- update pika from `0.11.2` to `0.12.0`