### PR TITLE
Make __OW_API_KEY available for action execution.

### DIFF
--- a/tests/src/test/scala/system/basic/WskBasicIBMPythonTests.scala
+++ b/tests/src/test/scala/system/basic/WskBasicIBMPythonTests.scala
@@ -18,6 +18,7 @@ package system.basic
 
 import common.{JsHelpers, TestHelpers, TestUtils, WhiskProperties, WskActorSystem, WskProps, WskTestHelpers}
 import common.rest.WskRestOperations
+import org.apache.openwhisk.core.entity.WhiskAction
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.Matchers
@@ -89,7 +90,11 @@ class WskBasicIBMPythonTests extends TestHelpers with WskTestHelpers with Matche
     (wp, assetHelper) =>
       val name = "stdenv"
       assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-        action.create(name, Some(TestUtils.getTestActionFilename("stdenv.py")), kind = Some(kind))
+        action.create(
+          name,
+          Some(TestUtils.getTestActionFilename("stdenv.py")),
+          kind = Some(kind),
+          annotations = Map(WhiskAction.provideApiKeyAnnotationName -> JsBoolean(true)))
       }
 
       withActivation(wsk.activation, wsk.action.invoke(name)) { activation =>


### PR DESCRIPTION
To have the environment variable __OW_API_KEY available inside an action now requires this to be enabled during action create step. 
This was introduced by a security fix in Openwhisk core.