### PR TITLE
Add PyJWT to support IBM Certificate Manager

### DIFF
--- a/python3.6/requirements.txt
+++ b/python3.6/requirements.txt
@@ -15,6 +15,7 @@ scrapy == 1.6.0
 simplejson == 3.16.0
 virtualenv == 16.3.0
 twisted == 18.9.0
+PyJWT == 1.7.1
 
 # packages for numerics
 numpy == 1.16.1

--- a/python3.7/requirements.txt
+++ b/python3.7/requirements.txt
@@ -15,6 +15,7 @@ scrapy == 1.6.0
 simplejson == 3.16.0
 virtualenv == 16.5.0
 twisted == 19.2.0
+PyJWT == 1.7.1
 
 # packages for numerics
 numpy == 1.16.3


### PR DESCRIPTION
I'd like to use IBM Functions to support all of the various IBM Certificate Manager workflows, such as ordering, renewing, expiring, etc... and to do so I need to decode a JWT encoded payload send in the notification.  Currently, this isn't possible via Python3 actions as a result of the PyJWT module not included as a requirement.