### PR TITLE
Get latest security fixes with each build.

### DIFF
--- a/python3.6/CHANGELOG.md
+++ b/python3.6/CHANGELOG.md
@@ -1,5 +1,10 @@
 # IBM Functions Python 3.6 Runtime Container
 
+## 1.25.1
+Changes:
+  - Catch latest security fixes with each build.
+
+
 ## 1.25.0
 Changes:
   - update to new base image

--- a/python3.6/Dockerfile
+++ b/python3.6/Dockerfile
@@ -5,8 +5,10 @@ ENV FLASK_PROXY_PORT 8080
 COPY requirements.txt requirements.txt
 
 RUN apt-get update \
+        # Upgrade installed packages to get latest security fixes if the base image does not contain them already.
+        && apt-get upgrade -y --no-install-recommends \
         # add some packages required for the pip install
-        && apt-get install -y \
+        && apt-get install -y --no-install-recommends \
            gcc \
            libc-dev \
            libxslt-dev \
@@ -16,12 +18,6 @@ RUN apt-get update \
            zip \
            unzip \
            vim \
-        # add secutity updates for certain packages
-        && apt-get install -y \
-           e2fsprogs \
-           openssl \
-           tzdata \
-           libgcrypt20 \
         # cleanup package lists, they are not used anymore in this image
         && rm -rf /var/lib/apt/lists/* \
         && apt-cache search linux-headers-generic \

--- a/python3.7/CHANGELOG.md
+++ b/python3.7/CHANGELOG.md
@@ -1,5 +1,9 @@
 # IBM Functions Python 3.7 Runtime Container
 
+## 1.14.1
+Changes:
+  - Catch latest security fixes with each build.
+
 ## 1.14.0
 Changes:
   - update to new base image

--- a/python3.7/Dockerfile
+++ b/python3.7/Dockerfile
@@ -3,8 +3,8 @@ FROM openwhisk/actionloop-python-v3.7:248efb5
 COPY requirements.txt requirements.txt
 
 RUN  apt-get update \
-     # add secutity updates for certain packages
-     && apt-get install -y --no-install-recommends file git curl\
+     # Upgrade installed packages to get latest security fixes if the base image does not contain them already.
+     && apt-get upgrade -y --no-install-recommends \
      # cleanup package lists, they are not used anymore in this image
      && rm -rf /var/lib/apt/lists/* \
      # We do not have mysql-server installed but mysql-common contains config files (/etc/mysql/my.cnf) for it.


### PR DESCRIPTION
Run `apt-get upgrade` with each build to always get the latest security fixes.
In case the base image is up to date (already contains the latest updates), this action is a no operation action.