### PR TITLE
Update Pillow on python3.7 to v6.2.2 to catch security fixes.

### DIFF
--- a/python3.7/CHANGELOG.md
+++ b/python3.7/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.15.0
 Changes:
   - update Twisted from `19.7.0` to `20.3.0` (security fixes)
+  - update Pillow from `6.2.1` to `6.2.2` (security fixes)
 
 Python version:
   - [3.7.5](https://github.com/docker-library/python/blob/ab8b829cfefdb460ebc17e570332f0479039e918/3.7/stretch/Dockerfile)
@@ -47,7 +48,7 @@ Python packages:
   - pandas==0.24.2
   - parsel==1.5.2
   - pika==1.0.1
-  - Pillow==6.2.1
+  - Pillow==6.2.2
   - pip==20.0.2
   - protobuf==3.11.3
   - psycopg2==2.8.2

--- a/python3.7/requirements.txt
+++ b/python3.7/requirements.txt
@@ -24,7 +24,7 @@ scipy == 1.2.1
 pandas == 0.24.2
 
 # packages for image processing
-Pillow == 6.2.1
+Pillow == 6.2.2
 
 # IBM specific python modules
 ibm_db == 3.0.1


### PR DESCRIPTION
  - CVE-2019-19911
  - CVE-2020-5313

Python 3.6 actually can not be updated due to backward incompatible changes in the new version.