### PR TITLE
Update ibmcloudsql and botocore.

### DIFF
--- a/python3.7/CHANGELOG.md
+++ b/python3.7/CHANGELOG.md
@@ -1,5 +1,90 @@
 # IBM Functions Python 3.7 Runtime Container
 
+## 1.17.0
+Changes:
+  - update ibmcloudsql from `0.3.13` to `0.3.14`
+
+Python version:
+  - [3.7.5](https://github.com/docker-library/python/blob/ab8b829cfefdb460ebc17e570332f0479039e918/3.7/stretch/Dockerfile)
+
+Python packages:
+  - attrs==19.3.0
+  - Automat==0.8.0
+  - beautifulsoup4==4.8.0
+  - botocore==1.15.46
+  - cassandra-driver==3.18.0
+  - certifi==2019.11.28
+  - cffi==1.13.2
+  - chardet==3.0.4
+  - click==7.1.1
+  - cloudant==2.12.0
+  - constantly==15.1.0
+  - cryptography==2.8
+  - cssselect==1.1.0
+  - docutils==0.15.2
+  - elasticsearch==6.3.1
+  - etcd3==0.10.0
+  - Flask==1.0.2
+  - gevent==1.4.0
+  - greenlet==0.4.15
+  - grpcio==1.28.1
+  - httplib2==0.13.0
+  - hyperlink==19.0.0
+  - ibm-cos-sdk==2.5.1
+  - ibm-cos-sdk-core==2.6.2
+  - ibm-cos-sdk-s3transfer==2.6.2
+  - ibm-db==3.0.1
+  - ibmcloudsql==0.3.14
+  - idna==2.7
+  - incremental==17.5.0
+  - itsdangerous==1.1.0
+  - Jinja2==2.11.2
+  - jmespath==0.9.5
+  - kafka-python==1.4.6
+  - lxml==4.3.4
+  - MarkupSafe==1.1.1
+  - numpy==1.16.4
+  - pandas==0.24.2
+  - parsel==1.5.2
+  - pika==1.0.1
+  - Pillow==6.2.2
+  - pip==20.0.2
+  - protobuf==3.11.3
+  - psycopg2==2.8.2
+  - pyarrow==0.15.1
+  - pyasn1==0.4.8
+  - pyasn1-modules==0.2.7
+  - pycparser==2.19
+  - PyDispatcher==2.0.5
+  - PyHamcrest==1.9.0
+  - PyJWT==1.7.1
+  - pymongo==3.8.0
+  - pyOpenSSL==19.1.0
+  - python-dateutil==2.8.0
+  - pytz==2019.3
+  - queuelib==1.5.0
+  - redis==3.2.1
+  - requests==2.22.0
+  - scikit-learn==0.20.3
+  - scipy==1.2.1
+  - Scrapy==1.6.0
+  - service-identity==18.1.0
+  - setuptools==46.1.3
+  - simplejson==3.16.0
+  - six==1.14.0
+  - soupsieve==2.0
+  - tenacity==6.1.0
+  - tornado==4.5.2
+  - Twisted==20.3.0
+  - urllib3==1.23
+  - virtualenv==16.7.1
+  - w3lib==1.21.0
+  - watson-developer-cloud==2.8.1
+  - websocket-client==0.48.0
+  - Werkzeug==1.0.1
+  - wheel==0.33.6
+  - zope.interface==4.7.1
+
 ## 1.16.0
 Changes:
   - update ibmcloudsql from `0.2.23` to `0.3.13`

--- a/python3.7/requirements.txt
+++ b/python3.7/requirements.txt
@@ -31,7 +31,7 @@ ibm_db == 3.0.1
 cloudant == 2.12.0
 watson-developer-cloud == 2.8.1
 ibm-cos-sdk == 2.5.1
-ibmcloudsql == 0.3.13
+ibmcloudsql == 0.3.14
 
 # Compose Libs
 psycopg2 == 2.8.2
@@ -41,3 +41,7 @@ pika == 1.0.1
 elasticsearch == 6.3.1
 cassandra-driver == 3.18.0
 etcd3 == 0.10.0
+
+# Other required modules
+botocore == 1.15.46
+tornado == 4.5.2


### PR DESCRIPTION
  - Update ibmcloudsql from `0.3.13` to `0.3.14`.
  - Explicitly add botocore `1.15.46` and tornado `4.5.2` to the requirements.txt file.
    These modules were indirectly required by ibmcloudsql before. The update to 0.3.13 removed these depdencies. Therefore the modules were not installed anymore.
    This caused actions to fail, since they were using e.g. botocore. Now adding these modules to have them again.
    In the future the build should take care, that no modules are removed. Even when introduced due to indirect dependencies.
    Because we can not be sure that users do not use them.