### PR TITLE
Refer to requirements.txt in CHANGELOG.md files.

### DIFF
--- a/python3.6/CHANGELOG.md
+++ b/python3.6/CHANGELOG.md
@@ -10,7 +10,7 @@ Python version:
 Python packages:
   - The file [requirements.txt](requirements.txt) lists the packages we guarantee to be included in this runtime.<br/>
     Ensure that you only use packages mentioned there.<br/>
-    Other python packages might be part of this runtime, but only due to indirect dependencies of the above listed packages. These indirect included packages are candidates to be removed at any time in case they are not required by the refering package anymore.
+    Other python packages might be part of this runtime, but only due to indirect dependencies of the above listed packages. These indirectly included packages are candidates to be removed at any time in case they are not required by the refering package anymore.
 
 
 ## 1.25.1

--- a/python3.6/CHANGELOG.md
+++ b/python3.6/CHANGELOG.md
@@ -9,7 +9,7 @@ Python version:
 
 Python packages:
   - The file [requirements.txt](requirements.txt) lists the packages we guarantee to be included in this runtime.<br/>
-    Ensure that you only use packages mentioned there!<br/>
+    Ensure that you only use packages mentioned there.<br/>
     Other python packages might be part of this runtime, but only due to indirect dependencies of the above listed packages. These indirect included packages are candidates to be removed at any time in case they are not required by the refering package anymore.
 
 

--- a/python3.6/CHANGELOG.md
+++ b/python3.6/CHANGELOG.md
@@ -8,78 +8,9 @@ Python version:
   - [3.6.9](https://github.com/docker-library/python/blob/721671c28aad96ad2c1970e83c2af71ceff15f1b/3.6/jessie/slim/Dockerfile)
 
 Python packages:
-  - attrs==19.3.0
-  - autobahn==20.2.1
-  - Automat==20.2.0
-  - beautifulsoup4==4.7.1
-  - botocore==1.15.5
-  - cassandra-driver==3.16.0
-  - certifi==2019.11.28
-  - cffi==1.14.0
-  - chardet==3.0.4
-  - Click==7.0
-  - cloudant==2.11.0
-  - constantly==15.1.0
-  - cryptography==2.8
-  - cssselect==1.1.0
-  - docutils==0.15.2
-  - elasticsearch==5.5.3
-  - Flask==1.0.2
-  - gevent==1.4.0
-  - greenlet==0.4.15
-  - httplib2==0.12.1
-  - hyperlink==19.0.0
-  - ibm-cos-sdk==2.4.3
-  - ibm-cos-sdk-core==2.6.0
-  - ibm-cos-sdk-s3transfer==2.6.0
-  - ibm-db==2.0.9
-  - ibmcloudsql==0.2.23
-  - idna==2.8
-  - incremental==17.5.0
-  - itsdangerous==1.1.0
-  - Jinja2==2.11.1
-  - jmespath==0.9.4
-  - kafka-python==1.4.4
-  - lxml==4.3.1
-  - MarkupSafe==1.1.1
-  - numpy==1.16.1
-  - pandas==0.24.1
-  - parsel==1.5.2
-  - pika==0.13.0
-  - Pillow==5.4.1
-  - pip==20.0.2
-  - psycopg2==2.7.7
-  - pyarrow==0.16.0
-  - pyasn1==0.4.8
-  - pyasn1-modules==0.2.8
-  - pycparser==2.19
-  - PyDispatcher==2.0.5
-  - PyHamcrest==2.0.0
-  - pymongo==3.7.2
-  - pyOpenSSL==19.1.0
-  - python-dateutil==2.7.5
-  - pytz==2019.3
-  - queuelib==1.5.0
-  - redis==2.10.6
-  - requests==2.21.0
-  - scikit-learn==0.20.2
-  - scipy==1.2.1
-  - Scrapy==1.6.0
-  - service-identity==18.1.0
-  - setuptools==45.2.0
-  - simplejson==3.16.0
-  - six==1.14.0
-  - soupsieve==2.0
-  - tornado==4.5.2
-  - Twisted==20.3.0
-  - txaio==20.1.1
-  - urllib3==1.24.3
-  - virtualenv==16.3.0
-  - w3lib==1.21.0
-  - watson-developer-cloud==1.7.1
-  - Werkzeug==1.0.0
-  - wheel==0.33.4
-  - zope.interface==4.7.1
+  - The file [requirements.txt](python3.7/requirements.txt) lists the packages/versions we guarantee to be included in this runtime.
+    Ensure that you only use packages mentioned there!
+    Other packages might be part of this runtime, but only due to indirect dependencies. These indirect packages are candidates to be removed at any time in case they are not required by the refering package anymore.
 
 
 ## 1.25.1

--- a/python3.6/CHANGELOG.md
+++ b/python3.6/CHANGELOG.md
@@ -8,7 +8,7 @@ Python version:
   - [3.6.9](https://github.com/docker-library/python/blob/721671c28aad96ad2c1970e83c2af71ceff15f1b/3.6/jessie/slim/Dockerfile)
 
 Python packages:
-  - The file [requirements.txt](python3.7/requirements.txt) lists the packages/versions we guarantee to be included in this runtime.
+  - The file [requirements.txt](requirements.txt) lists the packages/versions we guarantee to be included in this runtime.
     Ensure that you only use packages mentioned there!
     Other packages might be part of this runtime, but only due to indirect dependencies. These indirect packages are candidates to be removed at any time in case they are not required by the refering package anymore.
 

--- a/python3.6/CHANGELOG.md
+++ b/python3.6/CHANGELOG.md
@@ -8,10 +8,8 @@ Python version:
   - [3.6.9](https://github.com/docker-library/python/blob/721671c28aad96ad2c1970e83c2af71ceff15f1b/3.6/jessie/slim/Dockerfile)
 
 Python packages:
-  - The file [requirements.txt](requirements.txt) lists the packages/versions we guarantee to be included in this runtime.
-
-    Ensure that you only use packages mentioned there!
-
+  - The file [requirements.txt](requirements.txt) lists the packages we guarantee to be included in this runtime.<br/>
+    Ensure that you only use packages mentioned there!<br/>
     Other python packages might be part of this runtime, but only due to indirect dependencies of the above listed packages. These indirect included packages are candidates to be removed at any time in case they are not required by the refering package anymore.
 
 

--- a/python3.6/CHANGELOG.md
+++ b/python3.6/CHANGELOG.md
@@ -9,8 +9,10 @@ Python version:
 
 Python packages:
   - The file [requirements.txt](requirements.txt) lists the packages/versions we guarantee to be included in this runtime.
+
     Ensure that you only use packages mentioned there!
-    Other packages might be part of this runtime, but only due to indirect dependencies. These indirect packages are candidates to be removed at any time in case they are not required by the refering package anymore.
+
+    Other python packages might be part of this runtime, but only due to indirect dependencies of the above listed packages. These indirect included packages are candidates to be removed at any time in case they are not required by the refering package anymore.
 
 
 ## 1.25.1

--- a/python3.7/CHANGELOG.md
+++ b/python3.7/CHANGELOG.md
@@ -9,7 +9,7 @@ Python version:
 
 Python packages:
   - The file [requirements.txt](requirements.txt) lists the packages we guarantee to be included in this runtime.<br/>
-    Ensure that you only use packages mentioned there!<br/>
+    Ensure that you only use packages mentioned there.<br/>
     Other python packages might be part of this runtime, but only due to indirect dependencies of the above listed packages. These indirect included packages are candidates to be removed at any time in case they are not required by the refering package anymore.
 
 

--- a/python3.7/CHANGELOG.md
+++ b/python3.7/CHANGELOG.md
@@ -8,7 +8,7 @@ Python version:
   - [3.7.5](https://github.com/docker-library/python/blob/ab8b829cfefdb460ebc17e570332f0479039e918/3.7/stretch/Dockerfile)
 
 Python packages:
-  - The file [requirements.txt](python3.7/requirements.txt) lists the packages/versions we guarantee to be included in this runtime.
+  - The file [requirements.txt](requirements.txt) lists the packages/versions we guarantee to be included in this runtime.
     Ensure that you only use packages mentioned there!
     Other packages might be part of this runtime, but only due to indirect dependencies. These indirect packages are candidates to be removed at any time in case they are not required by the refering package anymore.
 

--- a/python3.7/CHANGELOG.md
+++ b/python3.7/CHANGELOG.md
@@ -9,8 +9,10 @@ Python version:
 
 Python packages:
   - The file [requirements.txt](requirements.txt) lists the packages/versions we guarantee to be included in this runtime.
+
     Ensure that you only use packages mentioned there!
-    Other packages might be part of this runtime, but only due to indirect dependencies. These indirect packages are candidates to be removed at any time in case they are not required by the refering package anymore.
+
+    Other python packages might be part of this runtime, but only due to indirect dependencies of the above listed packages. These indirect included packages are candidates to be removed at any time in case they are not required by the refering package anymore.
 
 
 ## 1.16.0

--- a/python3.7/CHANGELOG.md
+++ b/python3.7/CHANGELOG.md
@@ -8,10 +8,8 @@ Python version:
   - [3.7.5](https://github.com/docker-library/python/blob/ab8b829cfefdb460ebc17e570332f0479039e918/3.7/stretch/Dockerfile)
 
 Python packages:
-  - The file [requirements.txt](requirements.txt) lists the packages/versions we guarantee to be included in this runtime.
-
-    Ensure that you only use packages mentioned there!
-
+  - The file [requirements.txt](requirements.txt) lists the packages we guarantee to be included in this runtime.<br/>
+    Ensure that you only use packages mentioned there!<br/>
     Other python packages might be part of this runtime, but only due to indirect dependencies of the above listed packages. These indirect included packages are candidates to be removed at any time in case they are not required by the refering package anymore.
 
 

--- a/python3.7/CHANGELOG.md
+++ b/python3.7/CHANGELOG.md
@@ -8,82 +8,10 @@ Python version:
   - [3.7.5](https://github.com/docker-library/python/blob/ab8b829cfefdb460ebc17e570332f0479039e918/3.7/stretch/Dockerfile)
 
 Python packages:
-  - attrs==19.3.0
-  - Automat==0.8.0
-  - beautifulsoup4==4.8.0
-  - botocore==1.15.46
-  - cassandra-driver==3.18.0
-  - certifi==2019.11.28
-  - cffi==1.13.2
-  - chardet==3.0.4
-  - click==7.1.1
-  - cloudant==2.12.0
-  - constantly==15.1.0
-  - cryptography==2.8
-  - cssselect==1.1.0
-  - docutils==0.15.2
-  - elasticsearch==6.3.1
-  - etcd3==0.10.0
-  - Flask==1.0.2
-  - gevent==1.4.0
-  - greenlet==0.4.15
-  - grpcio==1.28.1
-  - httplib2==0.13.0
-  - hyperlink==19.0.0
-  - ibm-cos-sdk==2.5.1
-  - ibm-cos-sdk-core==2.6.2
-  - ibm-cos-sdk-s3transfer==2.6.2
-  - ibm-db==3.0.1
-  - ibmcloudsql==0.3.14
-  - idna==2.7
-  - incremental==17.5.0
-  - itsdangerous==1.1.0
-  - Jinja2==2.11.2
-  - jmespath==0.9.5
-  - kafka-python==1.4.6
-  - lxml==4.3.4
-  - MarkupSafe==1.1.1
-  - numpy==1.16.4
-  - pandas==0.24.2
-  - parsel==1.5.2
-  - pika==1.0.1
-  - Pillow==6.2.2
-  - pip==20.0.2
-  - protobuf==3.11.3
-  - psycopg2==2.8.2
-  - pyarrow==0.15.1
-  - pyasn1==0.4.8
-  - pyasn1-modules==0.2.7
-  - pycparser==2.19
-  - PyDispatcher==2.0.5
-  - PyHamcrest==1.9.0
-  - PyJWT==1.7.1
-  - pymongo==3.8.0
-  - pyOpenSSL==19.1.0
-  - python-dateutil==2.8.0
-  - pytz==2019.3
-  - queuelib==1.5.0
-  - redis==3.2.1
-  - requests==2.22.0
-  - scikit-learn==0.20.3
-  - scipy==1.2.1
-  - Scrapy==1.6.0
-  - service-identity==18.1.0
-  - setuptools==46.1.3
-  - simplejson==3.16.0
-  - six==1.14.0
-  - soupsieve==2.0
-  - tenacity==6.1.0
-  - tornado==4.5.2
-  - Twisted==20.3.0
-  - urllib3==1.23
-  - virtualenv==16.7.1
-  - w3lib==1.21.0
-  - watson-developer-cloud==2.8.1
-  - websocket-client==0.48.0
-  - Werkzeug==1.0.1
-  - wheel==0.33.6
-  - zope.interface==4.7.1
+  - The file [requirements.txt](python3.7/requirements.txt) lists the packages/versions we guarantee to be included in this runtime.
+    Ensure that you only use packages mentioned there!
+    Other packages might be part of this runtime, but only due to indirect dependencies. These indirect packages are candidates to be removed at any time in case they are not required by the refering package anymore.
+
 
 ## 1.16.0
 Changes:

--- a/python3.7/CHANGELOG.md
+++ b/python3.7/CHANGELOG.md
@@ -10,7 +10,7 @@ Python version:
 Python packages:
   - The file [requirements.txt](requirements.txt) lists the packages we guarantee to be included in this runtime.<br/>
     Ensure that you only use packages mentioned there.<br/>
-    Other python packages might be part of this runtime, but only due to indirect dependencies of the above listed packages. These indirect included packages are candidates to be removed at any time in case they are not required by the refering package anymore.
+    Other python packages might be part of this runtime, but only due to indirect dependencies of the above listed packages. These indirectly included packages are candidates to be removed at any time in case they are not required by the refering package anymore.
 
 
 ## 1.16.0


### PR DESCRIPTION
Refer to requirements.txt in CHANGELOG.md files instead of listing the packages there again.

Maintaining the list of included packages at 2 places (CHANGELOG.md and requirements.txt) causes additional effort for the maintainers and increases the chance for inconsistencies.