### PR TITLE
Update ibmcloudsql in python3.7 to v0.3.16, fix typos.

### DIFF
--- a/python3.6/CHANGELOG.md
+++ b/python3.6/CHANGELOG.md
@@ -10,7 +10,7 @@ Python version:
 Python packages:
   - The file [requirements.txt](requirements.txt) lists the packages we guarantee to be included in this runtime.<br/>
     Ensure that you only use packages mentioned there.<br/>
-    Other python packages might be part of this runtime, but only due to indirect dependencies of the above listed packages. These indirectly included packages are candidates to be removed at any time in case they are not required by the refering package anymore.
+    Other python packages might be part of this runtime, but only due to indirect dependencies of the above listed packages. These indirectly included packages are candidates to be removed at any time in case they are not required by the referring package anymore.
 
 
 ## 1.25.1

--- a/python3.7/CHANGELOG.md
+++ b/python3.7/CHANGELOG.md
@@ -1,5 +1,19 @@
 # IBM Functions Python 3.7 Runtime Container
 
+
+## 1.18.0
+Changes:
+  - update ibmcloudsql from `0.3.14` to `0.3.16`
+
+Python version:
+  - [3.7.5](https://github.com/docker-library/python/blob/ab8b829cfefdb460ebc17e570332f0479039e918/3.7/stretch/Dockerfile)
+
+Python packages:
+  - The file [requirements.txt](requirements.txt) lists the packages we guarantee to be included in this runtime.<br/>
+    Ensure that you only use packages mentioned there.<br/>
+    Other python packages might be part of this runtime, but only due to indirect dependencies of the above listed packages. These indirectly included packages are candidates to be removed at any time in case they are not required by the referring package anymore.
+
+
 ## 1.17.0
 Changes:
   - update ibmcloudsql from `0.3.13` to `0.3.14`
@@ -10,7 +24,7 @@ Python version:
 Python packages:
   - The file [requirements.txt](requirements.txt) lists the packages we guarantee to be included in this runtime.<br/>
     Ensure that you only use packages mentioned there.<br/>
-    Other python packages might be part of this runtime, but only due to indirect dependencies of the above listed packages. These indirectly included packages are candidates to be removed at any time in case they are not required by the refering package anymore.
+    Other python packages might be part of this runtime, but only due to indirect dependencies of the above listed packages. These indirectly included packages are candidates to be removed at any time in case they are not required by the referring package anymore.
 
 
 ## 1.16.0

--- a/python3.7/requirements.txt
+++ b/python3.7/requirements.txt
@@ -37,7 +37,7 @@ ibm_db == 3.0.1
 cloudant == 2.12.0
 watson-developer-cloud == 2.8.1
 ibm-cos-sdk == 2.5.1
-ibmcloudsql == 0.3.14
+ibmcloudsql == 0.3.16
 
 # Compose Libs
 psycopg2 == 2.8.2


### PR DESCRIPTION
- Update ibmcloudsql in python3.7 to v0.3.16.
- Fix typos.