### PR TITLE
Switch translation tests to 'it' as 'es' shows strange results.

### DIFF
--- a/tests/dat/watson/testWatsonService.py
+++ b/tests/dat/watson/testWatsonService.py
@@ -11,7 +11,7 @@ def main(args):
         username="APIKey",
         password=args.get("apikey"))
 
-    translation = language_translator.translate(text='Hello', model_id='en-es')
+    translation = language_translator.translate(text='Hello', model_id='en-it')
     if LooseVersion(sdk_version) < LooseVersion('2.0.0'):
         return translation
     else:

--- a/tests/src/test/scala/integration/CredentialsIBMPythonWatsonTests.scala
+++ b/tests/src/test/scala/integration/CredentialsIBMPythonWatsonTests.scala
@@ -44,7 +44,7 @@ class CredentialsIBMPythonWatsonTests extends TestHelpers with WskTestHelpers wi
   val apikey = creds.fields("apikey").asInstanceOf[JsString]
 
   /*
-    Uses Watson Translation Service to translate the word "Hello" in English, to "Hola" in Spanish.
+    Uses Watson Translation Service to translate the word "Hello" in English, to "Ciao" in Italian.
    */
   it should "Test whether watson translate service is reachable" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
     val file = Some(new File(datdir, actionFileName).toString())
@@ -61,7 +61,7 @@ class CredentialsIBMPythonWatsonTests extends TestHelpers with WskTestHelpers wi
       val response = activation.response
       response.result.get.fields.get("error") shouldBe empty
       response.result.get.fields.get("translations") should be(
-        Some(JsArray(JsObject("translation" -> JsString("Hola")))))
+        Some(JsArray(JsObject("translation" -> JsString("Ciao")))))
     }
 
   }


### PR DESCRIPTION
Switch the translation tests to 'it' as the up to now used 'es' now shows the English translation 'Hello' instead of the expected 'Hola'. No idea, why the result now is different than before. This may get fixed in the future, then we can switch back again. For the time being, the translation to 'it' shows the expected translation 'Ciao' and we use that for the tests.