### PR TITLE
Update python3.6 to `buster` based parent image.

### DIFF
--- a/python3.6/CHANGELOG.md
+++ b/python3.6/CHANGELOG.md
@@ -1,5 +1,18 @@
 # IBM Functions Python 3.6 Runtime Container
 
+## 1.27.0
+Changes:
+  - update to an actual `buster` based parent image as `jessie` reached end of service.
+
+Python version:
+  - [3.6.11](https://github.com/docker-library/python/blob/8341311c62812118a7e2046bbad66da21243f137/3.6/buster/slim/Dockerfile)
+
+Python packages:
+  - The file [requirements.txt](requirements.txt) lists the packages we guarantee to be included in this runtime.<br/>
+    Ensure that you only use packages mentioned there.<br/>
+    Other python packages might be part of this runtime, but only due to indirect dependencies of the above listed packages. These indirectly included packages are candidates to be removed at any time in case they are not required by the referring package anymore.
+
+
 ## 1.26.0
 Changes:
   - update Twisted from `19.7.0` to `20.3.0` (security fixes)

--- a/python3.6/Dockerfile
+++ b/python3.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim-jessie
+FROM python:3.6-slim-buster
 
 ENV FLASK_PROXY_PORT 8080
 


### PR DESCRIPTION
- Update python3.6 to a `buster` based parent image as the `jessie` based does not receive security updates anymore.