### PR TITLE
Update httplib2 and ibmcloudsql packages.

### DIFF
--- a/python3.6/CHANGELOG.md
+++ b/python3.6/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.27.0
 Changes:
   - update to an actual `buster` based parent image as `jessie` reached end of service.
+  - update httplib2 from `0.12.1` to `0.18.1` (security fixes)
 
 Python version:
   - [3.6.11](https://github.com/docker-library/python/blob/8341311c62812118a7e2046bbad66da21243f137/3.6/buster/slim/Dockerfile)

--- a/python3.6/requirements.txt
+++ b/python3.6/requirements.txt
@@ -12,7 +12,7 @@ flask == 1.0.2
 
 # default available packages for python3action
 beautifulsoup4 == 4.7.1
-httplib2 == 0.12.1
+httplib2 == 0.18.1
 kafka_python == 1.4.4
 lxml == 4.3.1
 python-dateutil == 2.7.5

--- a/python3.7/CHANGELOG.md
+++ b/python3.7/CHANGELOG.md
@@ -1,5 +1,17 @@
 # IBM Functions Python 3.7 Runtime Container
 
+## 1.19.0
+Changes:
+  - update httplib2 from `0.13.0` to `0.18.1`
+
+Python version:
+  - [3.7.5](https://github.com/docker-library/python/blob/ab8b829cfefdb460ebc17e570332f0479039e918/3.7/stretch/Dockerfile)
+
+Python packages:
+  - The file [requirements.txt](requirements.txt) lists the packages we guarantee to be included in this runtime.<br/>
+    Ensure that you only use packages mentioned there.<br/>
+    Other python packages might be part of this runtime, but only due to indirect dependencies of the above listed packages. These indirectly included packages are candidates to be removed at any time in case they are not required by the referring package anymore.
+
 
 ## 1.18.0
 Changes:

--- a/python3.7/CHANGELOG.md
+++ b/python3.7/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.19.0
 Changes:
   - update httplib2 from `0.13.0` to `0.18.1`
+  - update ibmcloudsql from `0.3.16` to `0.4.2`
 
 Python version:
   - [3.7.5](https://github.com/docker-library/python/blob/ab8b829cfefdb460ebc17e570332f0479039e918/3.7/stretch/Dockerfile)

--- a/python3.7/requirements.txt
+++ b/python3.7/requirements.txt
@@ -12,7 +12,7 @@ flask == 1.0.2
 
 # default available packages for python3action
 beautifulsoup4 == 4.8.0
-httplib2 == 0.13.0
+httplib2 == 0.18.1
 kafka_python == 1.4.6
 lxml == 4.3.4
 python-dateutil == 2.8.0

--- a/python3.7/requirements.txt
+++ b/python3.7/requirements.txt
@@ -37,7 +37,7 @@ ibm_db == 3.0.1
 cloudant == 2.12.0
 watson-developer-cloud == 2.8.1
 ibm-cos-sdk == 2.5.1
-ibmcloudsql == 0.3.16
+ibmcloudsql == 0.4.2
 
 # Compose Libs
 psycopg2 == 2.8.2


### PR DESCRIPTION
- Security update for httplib2 to v0.18.1.
- Update python3.7 package ibmcloudsql from `0.3.16` to `0.4.2`.