### PR TITLE
added new release of IBM Watson SDK

### DIFF
--- a/python3.7/requirements.txt
+++ b/python3.7/requirements.txt
@@ -36,6 +36,7 @@ Pillow == 6.2.2
 ibm_db == 3.0.1
 cloudant == 2.12.0
 watson-developer-cloud == 2.8.1
+ibm_cloud_sdk_core == 3.3.4
 ibm-watson == 5.0.2
 ibm-cos-sdk == 2.5.1
 ibmcloudsql == 0.4.11

--- a/python3.7/requirements.txt
+++ b/python3.7/requirements.txt
@@ -36,6 +36,7 @@ Pillow == 6.2.2
 ibm_db == 3.0.1
 cloudant == 2.12.0
 watson-developer-cloud == 2.8.1
+ibm-watson == 5.0.2
 ibm-cos-sdk == 2.5.1
 ibmcloudsql == 0.4.11
 


### PR DESCRIPTION
please support this new release of Watson SDK and companion auth library, otherwise every code example from the docs will not work in IBM Cloud Functions