### PR TITLE
Adapt to new apache/openwhisk commit.

### DIFF
--- a/ansible/environments/local/group_vars/all
+++ b/ansible/environments/local/group_vars/all
@@ -57,5 +57,3 @@ runtimes_manifest:
       deprecated: false
   blackboxes:
     - name: "dockerskeleton"
-
-controller_protocol: "http"

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,6 +11,7 @@ gradle.ext.openwhisk = [
 
 gradle.ext.scala = [
     version: '2.12.7',
+    depVersion  : '2.12',
     compileFlags: ['-feature', '-unchecked', '-deprecation', '-Xfatal-warnings', '-Ywarn-unused-import']
 ]
 
@@ -18,3 +19,6 @@ gradle.ext.scalafmt = [
     version: '1.5.0',
     config: new File(rootProject.projectDir, '.scalafmt.conf')
 ]
+
+gradle.ext.akka = [version : '2.6.12']
+gradle.ext.akka_http = [version : '10.2.4']

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -33,6 +33,12 @@ dependencies {
     compile "org.scala-lang:scala-library:${gradle.scala.version}"
     compile "org.apache.openwhisk:openwhisk-tests:${gradle.openwhisk.version}:tests"
     compile "org.apache.openwhisk:openwhisk-tests:${gradle.openwhisk.version}:test-sources"
+    implementation group: 'com.typesafe.akka', name: "akka-http2-support_${gradle.scala.depVersion}", version: "${gradle.akka_http.version}"
+    implementation group: 'com.typesafe.akka', name: "akka-http-xml_${gradle.scala.depVersion}", version: "${gradle.akka_http.version}"
+    implementation group: 'com.typesafe.akka', name: "akka-discovery_${gradle.scala.depVersion}", version: "${gradle.akka.version}"
+    implementation group: 'com.typesafe.akka', name: "akka-protobuf_${gradle.scala.depVersion}", version: "${gradle.akka.version}"
+    implementation group: 'com.typesafe.akka', name: "akka-remote_${gradle.scala.depVersion}", version: "${gradle.akka.version}"
+    implementation group: 'com.typesafe.akka', name: "akka-cluster_${gradle.scala.depVersion}", version: "${gradle.akka.version}"
 }
 
 tasks.withType(ScalaCompile) {

--- a/tests/src/test/resources/application.conf
+++ b/tests/src/test/resources/application.conf
@@ -1,0 +1,5 @@
+
+# For the runtime tests we use the same application.conf that is used
+# in the tests for the openwhisk environment itself.
+
+include file("../../openwhisk/tests/src/test/resources/application.conf")

--- a/tools/travis/setup.sh
+++ b/tools/travis/setup.sh
@@ -9,13 +9,13 @@ HOMEDIR="$SCRIPTDIR/../../../"
 
 # clone openWhisk
 cd $HOMEDIR
-# git clone --depth=1 https://github.com/apache/openwhisk.git openwhisk
-git clone https://github.com/apache/openwhisk.git openwhisk
+
+# Clone and setup openwhisk to have a local test environment.
+git clone https://github.com/apache/incubator-openwhisk.git openwhisk
 cd openwhisk
 # Use a fixed commit to run the tests, to explicitly control when changes are consumed.
-# Commit:  Update the notice year (#5122) 
-git checkout ecb2a980659f28d0adbd9ef837afaf4cb2b695bf
-
+# Commit: minor version bump of azure-storage-blob to fix builds (#5150)
+git checkout 3e6138d088fbd502a69c31314ad7c0089c5f5283
 
 # setup the openwhisk environment
 ./tools/travis/setup.sh


### PR DESCRIPTION
- Due to the removal of version 12.6.0 of the azure-storage-blob module on maven central openwhisk was updated to 12.7.0. Because of this we also needed to update to this new commit of openwhisk.