### PR TITLE
Security fixes for /bin/proxy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # IBM Cloud Functions Runtime for Python
-[![Build Status](https://travis-ci.org/ibm-functions/runtime-python.svg?branch=master)](https://travis-ci.org/ibm-functions/runtime-python)
+[![Build Status](https://travis-ci.com/ibm-functions/runtime-python.svg?branch=master)](https://travis-ci.com/ibm-functions/runtime-python)
 
 - The runtime provides [python v3.7](python3.7/) with a set of [python packages](python3.7/requirements.txt), see [python3.7/CHANGELOG.md](python3.7/CHANGELOG.md)
 - The runtime provides [python v3.6](python3.6/) with a set of [python packages](python3.6/requirements.txt), see [python3.6/CHANGELOG.md](python3.6/CHANGELOG.md)

--- a/python3.7/CHANGELOG.md
+++ b/python3.7/CHANGELOG.md
@@ -1,5 +1,17 @@
 # IBM Functions Python 3.7 Runtime Container
 
+## 1.22.4
+Changes:
+  - Update to new parent image to get latest go security fixes for the action loop proxy (/bin/proxy).
+
+Python version:
+  - [3.7.11](https://github.com/docker-library/python/blob/0c29e9cf700253291c7f2327537cb1d65f14a428/3.7/buster/Dockerfile)
+
+Python packages:
+  - The file [requirements.txt](requirements.txt) lists the packages we guarantee to be included in this runtime.<br/>
+    Ensure that you only use packages mentioned there.<br/>
+    Other python packages might be part of this runtime, but only due to indirect dependencies of the above listed packages. These indirectly included packages are candidates to be removed at any time in case they are not requ>
+
 ## 1.22.3
 Changes:
   - Update GO_PROXY_RELEASE_VERSION to 1.15@1.18.0.
@@ -12,7 +24,6 @@ Python packages:
   - The file [requirements.txt](requirements.txt) lists the packages we guarantee to be included in this runtime.<br/>
     Ensure that you only use packages mentioned there.<br/>
     Other python packages might be part of this runtime, but only due to indirect dependencies of the above listed packages. These indirectly included packages are candidates to be removed at any time in case they are not requ>
-
 
 ## 1.22.2
 Changes:

--- a/python3.7/Dockerfile
+++ b/python3.7/Dockerfile
@@ -1,4 +1,4 @@
-FROM openwhisk/action-python-v3.7:6925989
+FROM openwhisk/action-python-v3.7:16c6081
 
 COPY requirements.txt requirements.txt
 
@@ -11,4 +11,10 @@ RUN  apt-get update \
      # We need to add some dummy entries to /etc/mysql/my.cnf to sattisfy vulnerability checking of it.
      && echo "\n[mysqld]\nssl-ca=/tmp/ca.pem\nssl-cert=/tmp/server-cert.pem\nssl-key=/tmp/server-key.pem\n" >> /etc/mysql/my.cnf \
      # install additional python modules
-     && pip install --upgrade pip setuptools six && pip install --no-cache-dir -r requirements.txt
+     && pip install --upgrade pip setuptools six && pip install --no-cache-dir -r requirements.txt \
+     # Show actual python version in the build output.
+     && echo "Actual python version is:" \
+     && python --version \
+     # Show actual /bin/proxy version in the build output, makes it easier to check if go security fixes need to be applied.
+     && echo "Actual /bin/proxy version is:" \
+     && /bin/proxy -version


### PR DESCRIPTION
- Update to a new parent image to catch security fixes for the action loop proxy /bin/proxy.
- Also show the actual python and /bin/proxy version in the build output to make check if vulnerability fixes need to be applied easier.