### PR TITLE
Pin setuptools==57.5.0 to workaround ibm_db install issue.

### DIFF
--- a/python3.6/Dockerfile
+++ b/python3.6/Dockerfile
@@ -22,7 +22,12 @@ RUN apt-get update \
         && rm -rf /var/lib/apt/lists/* \
         && apt-cache search linux-headers-generic \
         # install additional python modules
-        && pip install --upgrade pip setuptools six && pip install --no-cache-dir -r requirements.txt \
+        #   we pin setuptools==57.5.0, reason is that ibm_db<=3.0.4 requires 'use_2to3' during install which has been
+        #   removed from setuptools starting with the 58.x.x release. The install therefore fails with:
+        #   error in ibm_db setup command: use_2to3 is invalid.
+        #   When ibm_db is upgraded to a version that does not need 'use_2to3' anymore the pin can also be removed.
+        && pip install --upgrade pip setuptools==57.5.0 six  \
+        && pip install --no-cache-dir -r requirements.txt \
         # create action working directory
         && mkdir -p /action \
         && mkdir -p /actionProxy \

--- a/python3.7/Dockerfile
+++ b/python3.7/Dockerfile
@@ -11,7 +11,12 @@ RUN  apt-get update \
      # We need to add some dummy entries to /etc/mysql/my.cnf to sattisfy vulnerability checking of it.
      && echo "\n[mysqld]\nssl-ca=/tmp/ca.pem\nssl-cert=/tmp/server-cert.pem\nssl-key=/tmp/server-key.pem\n" >> /etc/mysql/my.cnf \
      # install additional python modules
-     && pip install --upgrade pip setuptools six && pip install --no-cache-dir -r requirements.txt \
+     #   we pin setuptools==57.5.0, reason is that ibm_db<=3.0.4 requires 'use_2to3' during install which has been
+     #   removed from setuptools starting with the 58.x.x release. The install therefore fails with:
+     #   error in ibm_db setup command: use_2to3 is invalid.
+     #   When ibm_db is upgraded to a version that does not need 'use_2to3' anymore the pin can also be removed.
+     && pip install --upgrade pip setuptools==57.5.0 six  \
+     && pip install --no-cache-dir -r requirements.txt \
      # Show actual python version in the build output.
      && echo "Actual python version is:" \
      && python --version \


### PR DESCRIPTION
- With setuptools>=58.0.0 the installation of the ibm_db package fails with the error `use_2to3 is invalid.`. Reason is that this feature has been removed from setuptools beginning with 58.0.0. To actually make the build working again setuptools is pinned to the latest version before 58.0.0.
  When the ibm_db package later on is upgraded to a newer version where the install does not need `use_2to3` anymore, the pin of setuptools can be removed.

The related ibm_db issue is https://github.com/ibmdb/python-ibmdb/issues/655 .