### PR TITLE
Update Python 3.9 Packages for Vulnerability

### DIFF
--- a/python3.9/requirements.txt
+++ b/python3.9/requirements.txt
@@ -7,47 +7,47 @@
 
 
 # Setup modules
-gevent == 21.8.0
+gevent == 21.12.0
 flask == 2.0.2
 
 # default available packages for python3action
 beautifulsoup4 == 4.10.0 
 httplib2 == 0.20.2 
 kafka_python == 2.0.2
-lxml == 4.6.4
+lxml == 4.7.1
 python-dateutil == 2.8.2 
-requests ==  2.26.0 
+requests ==  2.27.1 
 scrapy ==  2.5.1 
 simplejson ==  3.17.6 
-virtualenv ==  20.10.0 
+virtualenv ==  20.13.0 
 twisted ==  21.7.0 
 PyJWT ==  2.3.0 
 
 # packages for numerics
-numpy == 1.21.4 
-scikit-learn == 1.0.1 
-scipy == 1.7.2 
-pandas == 1.3.4 
+numpy == 1.22.0
+scikit-learn == 1.0.2 
+scipy == 1.7.3
+pandas == 1.3.5 
 
 # packages for image processing
-Pillow == 8.4.0 
+Pillow == 9.0.0 
 
 # IBM specific python modules
-ibm_db == 3.1.0
-ibmcloudant == 0.0.40 
+ibm_db == 3.1.1
+ibmcloudant == 0.0.41 
 ibm-watson == 5.3.0
 ibm-cos-sdk == 2.10.0
-ibmcloudsql ==  0.5.0
+ibmcloudsql ==  0.5.2
 
 # Compose Libs
-psycopg2 == 2.9.2 
-pymongo == 3.12.1 
-redis == 4.0.1 
+psycopg2 == 2.9.3 
+pymongo == 4.0.1 
+redis == 4.1.0 
 pika == 1.2.0
-elasticsearch == 7.15.2
+elasticsearch == 7.16.3
 cassandra-driver == 3.25.0 
 etcd3 == 0.12.0 
 
 # Other required modules
-botocore == 1.23.8 
+botocore == 1.23.35 
 tornado == 6.1 


### PR DESCRIPTION
Vulnerability fixed in:
- Pillow == 9.0.0
- lxml == 4.7.1  

Updated Packages to latest version:
- gevent == 21.12.0
- requests ==  2.27.1 
- virtualenv ==  20.13.0
- numpy == 1.22.0
- scikit-learn == 1.0.2 
- scipy == 1.7.3
- pandas == 1.3.5
- ibm_db == 3.1.1
- ibmcloudant == 0.0.41 
- ibm-cos-sdk == 2.11.0
- ibmcloudsql ==  0.5.2
- psycopg2 == 2.9.3 
- pymongo == 4.0.1 
- redis == 4.1.0
- elasticsearch == 7.16.3
- botocore == 1.23.35 
- tornado == 6.1 