### PR TITLE
Update pip packeges to fix vulnerabilities

### DIFF
--- a/python3.9/CHANGELOG.md
+++ b/python3.9/CHANGELOG.md
@@ -9,6 +9,17 @@
     - [pypi ibm-watson](https://pypi.org/project/ibm-watson/)
     - [github ibm-watson](https://github.com/watson-developer-cloud/python-sdk)
 
+## 1.0.1
+Changes:
+  - update pip packages in requirements.txt
+  - lxml 4.7.1 -> 4.9.1
+  - twisted 21.7.0 -> 22.4.0
+  - PyJWT 2.3.0 -> 2.4.0
+  - Pillow = 9.0.0 -> 9.0.1
+
+Python version:
+- [3.9.13](https://www.python.org/downloads/release/python-3913/)
+
 ## 1.0.0
 Changes:
   - update all packages to their lates versions 

--- a/python3.9/requirements.txt
+++ b/python3.9/requirements.txt
@@ -14,14 +14,14 @@ flask == 2.0.2
 beautifulsoup4 == 4.10.0 
 httplib2 == 0.20.2 
 kafka_python == 2.0.2
-lxml == 4.7.1
+lxml == 4.9.1
 python-dateutil == 2.8.2 
 requests ==  2.27.1 
 scrapy ==  2.5.1 
 simplejson ==  3.17.6 
 virtualenv ==  20.13.0 
-twisted ==  21.7.0 
-PyJWT ==  2.3.0 
+twisted ==  22.4.0 
+PyJWT ==  2.4.0 
 
 # packages for numerics
 numpy == 1.22.0
@@ -30,7 +30,7 @@ scipy == 1.7.3
 pandas == 1.3.5 
 
 # packages for image processing
-Pillow == 9.0.0 
+Pillow == 9.0.1 
 
 # IBM specific python modules
 ibm_db == 3.1.1


### PR DESCRIPTION
Changes for new python 3.9 1.0.1 version
Changes:
  - update pip packages in requirements.txt
  - lxml 4.7.1 -> 4.9.1
  - twisted 21.7.0 -> 22.4.0
  - PyJWT 2.3.0 -> 2.4.0
  - Pillow = 9.0.0 -> 9.0.1

Python version:
- [3.9.13](https://www.python.org/downloads/release/python-3913/)