### PR TITLE
Build python:3.7, python:3.9 with --no-cache.

### DIFF
--- a/python3.7/build.gradle
+++ b/python3.7/build.gradle
@@ -1,2 +1,6 @@
 ext.dockerImageName = 'action-python-v3.7'
 apply from: '../gradle/docker.gradle'
+
+// To always get the latest vulnerability updates into the image, use --no-cache for building the image.
+// This is not needed for travis builds (the VM is always new), but for local development.
+dockerBuildArg = ['build','--no-cache']

--- a/python3.9/build.gradle
+++ b/python3.9/build.gradle
@@ -1,2 +1,6 @@
 ext.dockerImageName = 'action-python-v3.9'
 apply from: '../gradle/docker.gradle'
+
+// To always get the latest vulnerability updates into the image, use --no-cache for building the image.
+// This is not needed for travis builds (the VM is always new), but for local development.
+dockerBuildArg = ['build','--no-cache']


### PR DESCRIPTION
- Run docker build with --no-cache for python:3.7 and python:3.9 to always get latest security updates into the image. For travis builds this is not required (the travis VM is always empty). But local builds usually use the docker cache to speed up the build. They would not get the updates unless the Dockerfile is changed somewhere before the update/upgrade or the docker cache is cleared.