### PR TITLE
Remove python:3.6, python-jessie:3 from the tests.

### DIFF
--- a/ansible/environments/local/group_vars/all
+++ b/ansible/environments/local/group_vars/all
@@ -35,28 +35,13 @@ runtimes_manifest:
         name: "nodejs6action"
       deprecated: false
     python:
-    - kind: "python:2"
-      default: true
-      image:
-        name: "python2action"
-      deprecated: false
-    - kind: "python-jessie:3"
-      default: false
-      image:
-        name: "action-python-v3.6"
-      deprecated: false
-    - kind: "python:3.6"
-      default: false
-      image:
-        name: "action-python-v3.6"
-      deprecated: false
     - kind: "python:3.7"
       default: false
       image:
         name: "action-python-v3.7"
       deprecated: false
     - kind: "python:3.9"
-      default: false
+      default: true
       image:
         name: "action-python-v3.9"
       deprecated: false

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -15,6 +15,11 @@ tasks.withType(Test) {
         exceptionFormat = 'full'
     }
     outputs.upToDateWhen { false } // force tests to run every time
+
+    // We only test the python:3.7 and python:3.9 runtimes.
+    // The default python:3.6 is deprecated (it reached end of support).
+    include '**/*IBMPython37*'
+    include '**/*IBMPython39*'
 }
 
 task testWithoutCredentials(type: Test) {

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -26,8 +26,6 @@ docker pull ibmfunctions/invoker:nightly
 docker tag ibmfunctions/invoker:nightly ${IMAGE_PREFIX}/invoker
 docker pull openwhisk/nodejs6action:nightly
 docker tag openwhisk/nodejs6action:nightly nodejs6action
-docker pull openwhisk/python2action
-docker tag openwhisk/python2action python2action
 
 TERM=dumb ./gradlew install
 

--- a/tools/travis/test.sh
+++ b/tools/travis/test.sh
@@ -13,10 +13,6 @@ export OPENWHISK_HOME=$WHISKDIR
 WHISK_CLI="${WHISKDIR}/bin/wsk -i"
 
 # Run a simple action using the kind
-${WHISK_CLI} action update echoPython ${ROOTDIR}/tests/dat/echo.py --kind "python-jessie:3"
-${WHISK_CLI} action invoke echoPython -b
-${WHISK_CLI} action update echoPython ${ROOTDIR}/tests/dat/echo.py --kind "python:3.6"
-${WHISK_CLI} action invoke echoPython -b
 ${WHISK_CLI} action update echoPython ${ROOTDIR}/tests/dat/echo.py --kind "python:3.7"
 ${WHISK_CLI} action invoke echoPython -b
 ${WHISK_CLI} action update echoPython ${ROOTDIR}/tests/dat/echo.py --kind "python:3.9"
@@ -30,8 +26,6 @@ if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
 else
   TERM=dumb ./gradlew :tests:testWithoutCredentials
 fi
-
-
 
 
 #For some reason there no activations, maybe index not ready


### PR DESCRIPTION
- The Python 3.6 based runtimes are deprecated due to Python 3.6 end of support.