### PR TITLE
Vulnerability fixes for action loop, tornado, requests and flask.

### DIFF
--- a/python3.11/CHANGELOG.md
+++ b/python3.11/CHANGELOG.md
@@ -9,6 +9,21 @@
     - [pypi ibm-watson](https://pypi.org/project/ibm-watson/)
     - [github ibm-watson](https://github.com/watson-developer-cloud/python-sdk)
 
+## 1.1.0
+Changes:
+  - Bump to newer parent image (vulnerability fixes).
+  - Bump tornado from 6.2 to 6.3.2 (vulnerability fixes).
+  - Bump requests from 2.28.2 to 2.31.0 (vulnerability fixes).
+  - Bump flask from 2.2.3 to 2.3.2 (vulnerability fixes).
+
+Python version:
+  - [3.11.3](https://www.python.org/downloads/release/python-3113/)
+
+Python packages:
+  - The file [requirements.txt](requirements.txt) lists the packages we guarantee to be included in this runtime.<br/>
+    Ensure that you only use packages mentioned there.<br/>
+    Other python packages might be part of this runtime, but only due to indirect dependencies of the above listed packages. These indirectly included packages are candidates to be removed at any time in case they are not required by the referring package anymore.
+
 ## 1.0.0
 Changes:
  - actionloop proxy version 1.20@1.22.0

--- a/python3.11/Dockerfile
+++ b/python3.11/Dockerfile
@@ -1,4 +1,4 @@
-FROM openwhisk/action-python-v3.11:48b8a60
+FROM openwhisk/action-python-v3.11:3ed072d
 
 COPY requirements.txt requirements.txt
 

--- a/python3.11/requirements.txt
+++ b/python3.11/requirements.txt
@@ -8,20 +8,20 @@
 
 # Setup modules
 gevent == 22.10.2
-flask == 2.2.3
+flask == 2.3.2
 
 # default available packages for python3action
 beautifulsoup4 == 4.11.2
 httplib2 == 0.21.0
 kafka_python == 2.0.2
 lxml == 4.9.2
-python-dateutil == 2.8.2 
-requests ==  2.28.2 
-scrapy ==  2.8.0 
-simplejson ==  3.18.3 
-virtualenv ==  20.20.0 
-twisted ==  22.10.0 
-PyJWT ==  2.6.0 
+python-dateutil == 2.8.2
+requests ==  2.31.0
+scrapy ==  2.8.0
+simplejson ==  3.18.3
+virtualenv ==  20.20.0
+twisted ==  22.10.0
+PyJWT ==  2.6.0
 
 # packages for numerics
 numpy == 1.24.2
@@ -50,7 +50,7 @@ etcd3 == 0.12.0
 
 # Other required modules
 botocore == 1.29.86 
-tornado == 6.2 
+tornado == 6.3.2
 
 # required for etcd3 to work correctly can be removed at any time do not use in your own actions
 protobuf==4.22.1


### PR DESCRIPTION
  - Bump to newer parent image (vulnerability fixes).
  - Bump tornado from 6.2 to 6.3.2 (vulnerability fixes).
  - Bump requests from 2.28.2 to 2.31.0 (vulnerability fixes).
  - Bump flask from 2.2.3 to 2.3.2 (vulnerability fixes).