### PR TITLE
Update python3.11 to new parent image tag 1389697.

### DIFF
--- a/python3.11/CHANGELOG.md
+++ b/python3.11/CHANGELOG.md
@@ -9,6 +9,18 @@
     - [pypi ibm-watson](https://pypi.org/project/ibm-watson/)
     - [github ibm-watson](https://github.com/watson-developer-cloud/python-sdk)
 
+# 1.4.1
+Changes:
+  - Bump to newer parent image (vulnerability fixes) 1389697
+
+Python version:
+  - [3.11.8](https://www.python.org/downloads/release/python-3118/)
+
+Python packages:
+  - The file [requirements.txt](requirements.txt) lists the packages we guarantee to be included in this runtime.<br/>
+    Ensure that you only use packages mentioned there.<br/>
+    Other python packages might be part of this runtime, but only due to indirect dependencies of the above listed packages. These indirectly included packages are candidates to be removed at any time in case they are not required by the referring package anymore.
+
 # 1.4.0 
 Changes:
   - Bump to newer parent image (vulnerability fixes) c0a1e6d

--- a/python3.11/Dockerfile
+++ b/python3.11/Dockerfile
@@ -1,4 +1,4 @@
-FROM openwhisk/action-python-v3.11:c0a1e6d
+FROM openwhisk/action-python-v3.11:1389697
 
 COPY requirements.txt requirements.txt
 

--- a/tools/travis/test.sh
+++ b/tools/travis/test.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
-set -ex
+set -eEx
+trap "onError" ERR
+
+
+function onError() {
+
+  printf "Error in line $(caller)\n"
+  set -x
+  # When the script ends due to an error we dump the
+  # controller and invoker log to the output. This my help to
+  # analyze the error.
+  cat /tmp/wsklogs/invoker0/invoker0_logs.log || true
+  cat /tmp/wsklogs/controller0/controller0_logs.log || true
+
+}
+
 
 # Build script for Travis-CI.
 


### PR DESCRIPTION
- Update python3.11 to new parent image tag 1389697 to consume latest vulnerability fixes.